### PR TITLE
Added new BME Scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,12 +52,14 @@ find_package(catkin REQUIRED COMPONENTS
    FILES
    Num.msg
    LED.msg
+   Temp.msg
+   BME.msg
  )
 
 ## Generate services in the 'srv' folder
 # add_service_files(
 #   FILES
-#   AddTwoInts.srv
+#   TempCtoTempF.srv
 # )
 
 ## Generate actions in the 'action' folder
@@ -160,7 +162,7 @@ include_directories(
 ## Mark executable scripts (Python etc.) for installation
 ## in contrast to setup.py, you can choose the destination
 catkin_install_python(PROGRAMS
-  scripts/talker.py scripts/listener.py scripts/led_controller.py scripts/led_receiver.py
+  scripts/talker.py scripts/listener.py scripts/led_controller.py scripts/led_receiver.py scripts/temp_listen_convert.py scripts/temp_read_publish.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
  )
 

--- a/msg/BME.msg
+++ b/msg/BME.msg
@@ -1,0 +1,3 @@
+float64 temp
+float64 pressure
+float64 humidity

--- a/msg/Temp.msg
+++ b/msg/Temp.msg
@@ -1,0 +1,1 @@
+float64 temp

--- a/scripts/temp_listen_convert.py
+++ b/scripts/temp_listen_convert.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Based on the simple publisher/subscriber tutorial on the ROS tutorial page:
+# https://github/ros/ros_tutorials.com
+# Software License Agreement (GPLv3 License)
+
+import rospy
+from subprocess import Popen, PIPE
+from led_test.msg import BME
+
+def callback(data):
+    #rospy.loginfo(rospy.get_caller_id() + 'I heard %s', data.temp)
+    temp_c = data.temp
+    temp_f = data.temp*9.0/5.0+32.0
+    rospy.loginfo('T: %s P: %s H: %s ',temp_f,data.pressure,data.humidity)
+
+first_flag=True
+def listener():
+    # In ROS, nodes are uniquely named. If two nodes with the same
+    # name are launched, the previous one is kicked off. The
+    # anonymous=True flag means that rospy will choose a unique
+    # name for our 'listener' node so that multiple listeners can
+    # run simultaneously.
+    rospy.init_node('listener', anonymous=True)
+
+    rospy.Subscriber('bme280', BME, callback) #subscribe to chatter topic
+    
+    # spin() simply keeps python from exiting until this node is stopped
+    rospy.spin()
+
+if __name__ == '__main__':
+    # Popen(['sudo','python3','/home/ubuntu/catkin_ws/src/led_test/python_scripts/blink_test.py'], stdout=PIPE, stderr=PIPE) 
+    Popen(['sudo','python3','blink_test.py'],stdout=PIPE,stderr=PIPE)
+    listener()

--- a/scripts/temp_read_publish.py
+++ b/scripts/temp_read_publish.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# Based on the simple publisher/subscriber tutorial on the ROS tutorial page:
+# https://github/ros/ros_tutorials.com
+# Based on the simple publisher/subscriber tutorial on the ROS tutorial page:
+# https://github/ros/ros_tutorials.com
+# Also based on the BME280 demo script found at http://bit.ly/bme280py
+# Software License Agreement (GPLv3 License)
+
+import rospy
+import smbus
+import time
+from led_test.msg import BME
+from ctypes import c_short
+from ctypes import c_byte
+from ctypes import c_ubyte
+
+DEVICE = 0x76 # Default device I2C address
+
+
+bus = smbus.SMBus(1) # Rev 2 Pi, Pi 2 & Pi 3 uses bus 1
+                     # Rev 1 Pi uses bus 0
+
+def getShort(data, index):
+  # return two bytes from data as a signed 16-bit value
+  return c_short((data[index+1] << 8) + data[index]).value
+
+def getUShort(data, index):
+  # return two bytes from data as an unsigned 16-bit value
+  return (data[index+1] << 8) + data[index]
+
+def getChar(data,index):
+  # return one byte from data as a signed char
+  result = data[index]
+  if result > 127:
+    result -= 256
+  return result
+
+def getUChar(data,index):
+  # return one byte from data as an unsigned char
+  result =  data[index] & 0xFF
+  return result
+
+def readBME280ID(addr=DEVICE):
+  # Chip ID Register Address
+  REG_ID     = 0xD0
+  (chip_id, chip_version) = bus.read_i2c_block_data(addr, REG_ID, 2)
+  return (chip_id, chip_version)
+
+def readBME280All(addr=DEVICE):
+  # Register Addresses
+  REG_DATA = 0xF7
+  REG_CONTROL = 0xF4
+  REG_CONFIG  = 0xF5
+
+  REG_CONTROL_HUM = 0xF2
+  REG_HUM_MSB = 0xFD
+  REG_HUM_LSB = 0xFE
+
+  # Oversample setting - page 27
+  OVERSAMPLE_TEMP = 2
+  OVERSAMPLE_PRES = 2
+  MODE = 1
+
+  # Oversample setting for humidity register - page 26
+  OVERSAMPLE_HUM = 2
+  bus.write_byte_data(addr, REG_CONTROL_HUM, OVERSAMPLE_HUM)
+
+  control = OVERSAMPLE_TEMP<<5 | OVERSAMPLE_PRES<<2 | MODE
+  bus.write_byte_data(addr, REG_CONTROL, control)
+
+  # Read blocks of calibration data from EEPROM
+  # See Page 22 data sheet
+  cal1 = bus.read_i2c_block_data(addr, 0x88, 24)
+  cal2 = bus.read_i2c_block_data(addr, 0xA1, 1)
+  cal3 = bus.read_i2c_block_data(addr, 0xE1, 7)
+
+  # Convert byte data to word values
+  dig_T1 = getUShort(cal1, 0)
+  dig_T2 = getShort(cal1, 2)
+  dig_T3 = getShort(cal1, 4)
+
+  dig_P1 = getUShort(cal1, 6)
+  dig_P2 = getShort(cal1, 8)
+  dig_P3 = getShort(cal1, 10)
+  dig_P4 = getShort(cal1, 12)
+  dig_P5 = getShort(cal1, 14)
+  dig_P6 = getShort(cal1, 16)
+  dig_P7 = getShort(cal1, 18)
+  dig_P8 = getShort(cal1, 20)
+  dig_P9 = getShort(cal1, 22)
+
+  dig_H1 = getUChar(cal2, 0)
+  dig_H2 = getShort(cal3, 0)
+  dig_H3 = getUChar(cal3, 2)
+
+  dig_H4 = getChar(cal3, 3)
+  dig_H4 = (dig_H4 << 24) >> 20
+  dig_H4 = dig_H4 | (getChar(cal3, 4) & 0x0F)
+
+  dig_H5 = getChar(cal3, 5)
+  dig_H5 = (dig_H5 << 24) >> 20
+  dig_H5 = dig_H5 | (getUChar(cal3, 4) >> 4 & 0x0F)
+
+  dig_H6 = getChar(cal3, 6)
+
+  # Wait in ms (Datasheet Appendix B: Measurement time and current calculation)
+  wait_time = 1.25 + (2.3 * OVERSAMPLE_TEMP) + ((2.3 * OVERSAMPLE_PRES) + 0.575) + ((2.3 * OVERSAMPLE_HUM)+0.575)
+  time.sleep(wait_time/1000)  # Wait the required time  
+
+  # Read temperature/pressure/humidity
+  data = bus.read_i2c_block_data(addr, REG_DATA, 8)
+  pres_raw = (data[0] << 12) | (data[1] << 4) | (data[2] >> 4)
+  temp_raw = (data[3] << 12) | (data[4] << 4) | (data[5] >> 4)
+  hum_raw = (data[6] << 8) | data[7]
+
+  #Refine temperature
+  var1 = ((((temp_raw>>3)-(dig_T1<<1)))*(dig_T2)) >> 11
+  var2 = (((((temp_raw>>4) - (dig_T1)) * ((temp_raw>>4) - (dig_T1))) >> 12) * (dig_T3)) >> 14
+  t_fine = var1+var2
+  temperature = float(((t_fine * 5) + 128) >> 8);
+
+  # Refine pressure and adjust for temperature
+  var1 = t_fine / 2.0 - 64000.0
+  var2 = var1 * var1 * dig_P6 / 32768.0
+  var2 = var2 + var1 * dig_P5 * 2.0
+  var2 = var2 / 4.0 + dig_P4 * 65536.0
+  var1 = (dig_P3 * var1 * var1 / 524288.0 + dig_P2 * var1) / 524288.0
+  var1 = (1.0 + var1 / 32768.0) * dig_P1
+  if var1 == 0:
+    pressure=0
+  else:
+    pressure = 1048576.0 - pres_raw
+    pressure = ((pressure - var2 / 4096.0) * 6250.0) / var1
+    var1 = dig_P9 * pressure * pressure / 2147483648.0
+    var2 = pressure * dig_P8 / 32768.0
+    pressure = pressure + (var1 + var2 + dig_P7) / 16.0
+
+  # Refine humidity
+  humidity = t_fine - 76800.0
+  humidity = (hum_raw - (dig_H4 * 64.0 + dig_H5 / 16384.0 * humidity)) * (dig_H2 / 65536.0 * (1.0 + dig_H6 / 67108864.0 * humidity * (1.0 + dig_H3 / 67108864.0 * humidity)))
+  humidity = humidity * (1.0 - dig_H1 * humidity / 524288.0)
+  if humidity > 100:
+    humidity = 100
+  elif humidity < 0:
+    humidity = 0
+
+  return temperature/100.0,pressure/100.0,humidity
+
+def talker():
+    pub = rospy.Publisher('bme280', BME, queue_size=10)
+    rospy.init_node('talker', anonymous=True)
+    rate = rospy.Rate(10) # 10hz
+    while not rospy.is_shutdown():
+        temperature,pressure,humidity = readBME280All() #read BME280
+        hello_str = "Temperature %s" % temperature #convert to string
+        rospy.loginfo('T: %s P: %s H: %s', temperature, pressure, humidity) 
+        pub.publish(float(temperature),float(pressure),float(humidity)) #publish to temperature topic
+        rate.sleep()
+
+if __name__ == '__main__':
+    try:
+        talker()
+    except rospy.ROSInterruptException:
+        pass


### PR DESCRIPTION
Added 2 new message types in /msg: Temp (currently unused, float64) and BME. BME has three fields: temp (float64), pressure (float64), and humidity (float64). Added 2 new scripts in /scripts: temp_listen_convert.py and temp_read_publish.py. temp_listen_convert.py listens on the bme topic for BME messages, and converts the temperature received from Celcius to Fahrenheit before displaying them with rospy.logger(). temp_read_publish.py is similar to talker.py in that it reads the BME data and publishes it, now on the bme topic. The main difference is that this uses the BME message type instead of the standard Float64 message type to send pressure and humidity along with temperature. 